### PR TITLE
RSC 等の用語を公式に寄せる

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # RSC Boundary Marker
 
-Visualize the boundary between RSC (React Server Components) and Client Components in your React codebase.
+Visualize the `'use client'` boundary in your React codebase from the caller's side.
 
 ## Features
 
-- **Automatic Detection**: Automatically identifies Client Component imports in your React components
-- **Visual Markers**: Shows clear visual indicators (`Client Component`) next to Client Components
+- **Automatic Detection**: Automatically identifies Components with `'use client'` impoted and rendered in your React components
+- **Visual Markers**: Shows clear visual indicators (`Client Component`) next to the Components with `'use client'`.
 
 ## How It Works
 
-The extension scans your React files and marks any usage of Client Components (files with `"use client"` directive) with a visual indicator.
+The extension scans your React files and marks any usage of Components with `"use client"` directive, and mark them with a visual indicator.
 
 ```jsx
 // File with "use client" directive

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Visualize the `'use client'` boundary in your React codebase from the caller's s
 
 ## Features
 
-- **Automatic Detection**: Automatically identifies Components with `'use client'` impoted and rendered in your React components
+- **Automatic Detection**: Automatically identifies Components with `'use client'` imported in your React components
 - **Visual Markers**: Shows clear visual indicators (`Client Component`) next to the Components with `'use client'`.
 
 ## How It Works


### PR DESCRIPTION
めっちゃ良いです！！

細かい点で恐縮ですが、この拡張機能の説明文に少し不正確な点があるので、修正するほうが良いと思います。
 
ご存知だったら恐縮ですが、一応整理しておきます

- RSC と Server Components の違い
  - https://ja.react.dev/reference/rsc/server-components
  - RSC (React Server Components)
    -  アーキテクチャそのものの名前
  - Server Components
    - Server環境でレンダリングされるコンポーネント
- "use client" の有 / 無と、 Client Component / Server Component は1:1対応じゃない
  - `"use client"` の無いコンポーネントは、
    - 呼び出し元が Client Component であれば、Client Component としてレンダリングされる
    - 呼び出し元が Server Component であれば、Server Component としてレンダリングされる

## ついでの仕様変更提案


ついでの提案になりますが、表示するマーカーについても、`Client Component` ではなく、`'use client'` または `'use client' Boundary`みたいに表示するほうが良いと思います。